### PR TITLE
feat: set type annotation spacing

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -17,6 +17,19 @@
         }
       }
     ],
+    "@typescript-eslint/type-annotation-spacing": [
+      "error",
+      {
+        "before": false,
+        "after": true,
+        "overrides": {
+          "arrow": {
+            "before": true,
+            "after": true
+          }
+        }
+      }
+    ],
     "arrow-body-style": [
       "error",
       "as-needed"


### PR DESCRIPTION
This change institutes a convention for [spacing around type annotations](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/type-annotation-spacing.md), specifically:

**For variables,** space only after colon:

```ts
const abc: string = "def"
```

**For return types,** the same:

```ts
const abc = (): string => "def"
```

There is an exception for **arrow functions,** which are part of the rule's scope. For these we have a space before and after the arrow, as shown above.